### PR TITLE
Bubblewrap and .mount units fix

### DIFF
--- a/src/package.nix
+++ b/src/package.nix
@@ -32,9 +32,7 @@ let
     extraBwrapArgs = [
       "--bind /var/snap /var/snap"
       "--bind /snap /snap"
-      # https://github.com/io12/nix-snapd/issues/4
-      "--bind /etc/fonts /etc/fonts"
-      "--tmpfs /etc/oracle-cloud-agent"
+      "--bind-try /etc/oracle-cloud-agent /etc/oracle-cloud-agent"
     ];
     targetPkgs = pkgs:
       (with pkgs; [

--- a/src/package.nix
+++ b/src/package.nix
@@ -34,7 +34,7 @@ let
       "--bind /snap /snap"
       # https://github.com/io12/nix-snapd/issues/4
       "--bind /etc/fonts /etc/fonts"
-      "--bind /etc/oracle-cloud-agent /etc/oracle-cloud-agent"
+      "--tmpfs /etc/oracle-cloud-agent"
     ];
     targetPkgs = pkgs:
       (with pkgs; [


### PR DESCRIPTION
So,

this updates the FHS env from `buildFHSEnvChroot` ([which is deprecated](https://github.com/NixOS/nixpkgs/blob/6b78a949091c51385c46c7e8e7ce9293b5098fc8/nixos/doc/manual/release-notes/rl-2305.section.md?plain=1#L570)) to `buildFHSEnvChroot`.

`buildFHSEnvBubblewrap` [bind-mounts /etc/fonts by default](https://github.com/NixOS/nixpkgs/blob/e17e9f572554e39dfe00cf9240e5625308727236/pkgs/build-support/build-fhsenv-bubblewrap/default.nix#L89) which probably helps with https://github.com/io12/nix-snapd/issues/4 

There's a few extras:
- .mount files in `/var/lib/snapd/nix-systemd-system` are now symlinked to `/run/systemd/system`. W/o this installing my beloved (/s) oracle-cloud-agent snap would prevent snapd from starting at all.
- A few select /etc dirs are attempted to be bind-mounted into the env: `/etc/oracle-cloud-agent` (again, oca wouldn't start w/o it). I don't quite know how to make these bind mounts less static. Ideally, we'd bind-mount `/etc` entirely - maybe?