### PR TITLE
test: remove microk8s

### DIFF
--- a/src/test/default.nix
+++ b/src/test/default.nix
@@ -12,7 +12,7 @@ let
   # Download tested snaps with a fixed-output derivation because the test runner
   # normally doesn't have internet access
   downloadedSnaps =
-    pkgs.runCommand "downloaded-snaps"
+    pkgs.runCommand "${system}-downloaded-snaps"
       {
         buildInputs = [
           snap
@@ -56,7 +56,6 @@ nixos-lib.runTest {
 
     # Ensure snap programs aren't already installed
     machine.fail("hello-world")
-    machine.fail("microk8s version")
     machine.fail("gnome-calculator")
 
     # Install snaps
@@ -81,7 +80,6 @@ nixos-lib.runTest {
 
       assert machine.succeed("hello-world") == "Hello World!\n"
       assert machine.succeed("su - alice -c hello-world") == "Hello World!\n"
-      assert machine.succeed("microk8s version").startswith("MicroK8s v1.29.4")
 
       # Test gnome-calculator snap
       machine.wait_for_x()

--- a/src/test/pinned-snap-versions.toml
+++ b/src/test/pinned-snap-versions.toml
@@ -1,5 +1,5 @@
 [x86_64-linux]
-hash = "sha256-CGM3L/4sQ0MJ5fN92ZJ+oPwFR4DX/06Z45v9g3HTcAM="
+hash = "sha256-qWyIkUwarH1t4mZ+rrFuThARbhfguQSXR+Iag1K7H0g="
 snaps = [
     { name = "bare", rev = 5 },
     { name = "core", rev = 16928 },
@@ -9,11 +9,10 @@ snaps = [
     { name = "gtk-common-themes", rev = 1535 },
     { name = "gnome-calculator", rev = 955 },
     { name = "hello-world", rev = 29 },
-    { name = "microk8s", rev = 6809, classic = true },
 ]
 
 [aarch64-linux]
-hash = "sha256-a3rBsutW3X3WiUG5jk0WJKjqHvzppFrNNL/lKeYf5VM="
+hash = "sha256-wzeVDwCLPxJQPFbyaVpbDncX8GJMX8uL0oliteokZZo="
 snaps = [
     { name = "bare", rev = 5 },
     { name = "core", rev = 16931 },
@@ -23,5 +22,4 @@ snaps = [
     { name = "gtk-common-themes", rev = 1535 },
     { name = "gnome-calculator", rev = 956 },
     { name = "hello-world", rev = 29 },
-    { name = "microk8s", rev = 6808, classic = true },
 ]


### PR DESCRIPTION
Microk8s doesn't actually work, and slows the test down and fills the logs due to retried operations in the background.